### PR TITLE
removing module.exports.getName

### DIFF
--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -7,8 +7,4 @@ module.exports = {
       // format large numbers with commas
       return parseInt(amount).toLocaleString();
     },
-},
-
-module.exports.getName = (name) => {
-  return 'user'
 }


### PR DESCRIPTION
I thought that module.exports.getName would have gotten the user's name into the comment history. It didn't do anything.